### PR TITLE
Extend sample layout in rendered component

### DIFF
--- a/content/templates/_components/example/example-1.jade
+++ b/content/templates/_components/example/example-1.jade
@@ -1,3 +1,1 @@
 button.btn.btn-primary Primary button
-
-+icon('example')

--- a/content/templates/_components/example/example-1.jade
+++ b/content/templates/_components/example/example-1.jade
@@ -1,1 +1,3 @@
 button.btn.btn-primary Primary button
+
++icon('example')

--- a/core/templates/layouts/sample.jade
+++ b/core/templates/layouts/sample.jade
@@ -1,0 +1,3 @@
+include ../mixins/icon
+
+block content

--- a/core/templates/locals.js
+++ b/core/templates/locals.js
@@ -39,7 +39,10 @@ function getDefaultLocals() {
     if (!language || language === 'jade') {
       return jadeMarkup;
     } else if (language === 'html') {
-      return jade.compile(jadeMarkup, {
+      const indentedJadeMarkup = jadeMarkup.split('\n').map(line => `\t${line}`).join('\n');
+      const markupWithLayout = `extends /../core/templates/layouts/sample\n\nblock content\n${indentedJadeMarkup}`;
+
+      return jade.compile(markupWithLayout, {
         pretty: true,
         basedir: 'content',
         filename: componentFileLocation


### PR DESCRIPTION
This adds some extra Jade markup to a rendered component, which results in it extending a new layout specifically for samples (`core/templates/layouts/sample.jade`). This layout includes the icon mixin, allowing the icon mixin to be used globally. Other stuff can also be added to this layout should you find a need for other global mixins.

In other words, a component with the following Jade markup:

```jade
button.btn.btn-primary Primary button
+icon('example')
```

Will actually render as:

```jade
extends /../core/templates/layouts/sample

block content
    button.btn.btn-primary Primary button
    +icon('example')
```