### PR TITLE
Evo: basic multilingual support

### DIFF
--- a/bedrock.config.js
+++ b/bedrock.config.js
@@ -17,6 +17,14 @@ module.exports = {
       c: 'Custom components'
     }
   },
+  languages: [{
+    id: "langEn",
+    label: "English",
+    default: true
+  },{
+    id: "langFr",
+    label: "Français"
+  }],
   ui: {
     dark: false
   },

--- a/content/templates/module/form-example.pug
+++ b/content/templates/module/form-example.pug
@@ -3,16 +3,24 @@ extends /templates/_layouts/master
 block body
 
     if error
-        p(style="color: red") Hey! Some fields were marked as invalid.
+        p(style="color: red") 
+            span(data-lang="langEn") Hey! Some fields were marked as invalid.
+            span(data-lang="langFr") Oups! Certain champs sont invalides.
 
     p
-        label First Name
+        label
+            span(data-lang="langEn") First Name
+            span(data-lang="langFr") Nom
         input(type="text")
     p
-        label Last Name
+        label
+            span(data-lang="langEn") Last Name
+            span(data-lang="langFr") Prénom
         input(type="text")
     p
-        label Message
+        label
+            span(data-lang="langEn") Message
+            span(data-lang="langFr") Message
         textarea
 
     input(type="submit")

--- a/core/js/prototype-nav.js
+++ b/core/js/prototype-nav.js
@@ -1,5 +1,6 @@
 const $ = require('jquery');
 const packageJson = require('../../package.json');
+const config = require('../../bedrock.config');
 
 const ACTIVATION_KEYCODE = 77; // 'M' key or 'B' key for Windows
 const ACTIVATION_KEYCODE_WINDOWS = 66; // 'M' key or 'B' key for Windows
@@ -9,6 +10,7 @@ const NAV_STATE_STORAGE_KEY = `bedrock.${packageJson.name}.prototypeNavState`;
 let navState = {
   isOpen: false,
   closedModules: [],
+  langSelected: config.languages && config.languages.find((lang) => lang.default).id
 };
 
 const $html = $('html');
@@ -121,3 +123,30 @@ $(window).on('keyup', function (e) {
     toggleNavigation();
   }
 });
+
+
+/**
+ * Multilanguage logic
+ */
+ function displayLanguageLabels(lang) {
+  // Switch label on this page
+  $('[data-lang][data-lang!='+lang+']').css('display', 'none')
+  $('[data-lang='+lang+']').css('display', 'inline-block')
+ }
+
+ function checkLangSelected(lang) {
+  $('#'+lang+'.br-prototype-langselector').prop('checked', true);
+ }
+
+$('.br-prototype-langselector').on('change',function() {
+  var newLang = this.value;
+  // Switch label on this page
+  displayLanguageLabels(newLang)
+  // Persist language selection
+  navState.langSelected = newLang;
+  saveNavState();
+});
+
+// Execute on each page refresh
+checkLangSelected(navState.langSelected);
+displayLanguageLabels(navState.langSelected);

--- a/core/scss/components/_br-prototype-nav.scss
+++ b/core/scss/components/_br-prototype-nav.scss
@@ -49,6 +49,10 @@ html.br-prototype-nav-is-open {
   }
 }
 
+.br-prototype-langselector {
+  margin-bottom: 10px;
+}
+
 .br-prototype-nav-text {
   margin: 0;
   padding: 0 0 0.6rem*$br-base-size-multiplier;

--- a/core/templates/includes/prototype-nav.pug
+++ b/core/templates/includes/prototype-nav.pug
@@ -8,6 +8,13 @@ include ../mixins/render-page-tree
     .br-prototype-nav-inner
         h3.br-prototype-nav-main-heading Prototype navigation
         p.br-prototype-nav-text Press Ctrl + M to toggle this navigation or click <a class="br-prototype-close-nav" href="#">here</a>.
+        
+        if config.languages && config.languages.length > 1
+            p.br-prototype-nav-text Language selection:
+            each lang in config.languages
+                input(class='br-prototype-langselector',type='radio', name='lang', id=lang.id, value=lang.id, checked=lang.default===true)
+                label(for=lang.id)= lang.label
+        
         +renderPageTree
 
     if basePage && basePage.states


### PR DESCRIPTION
Hello @Wolfr , here is a first shot at the multilingual support, the doc on how to use it _(that we should add to the official doc website when we agree on the feature)_ , regarding feature implem I let you review the PR but it's fairly simple I just persist a new variable for the language selection along with the sidebar state. Regarding styling we could have something a bit better in the prototype-nav.pug, I think if we add a third language the radio button may be a bit ugly 😉.

### DOC: How to add multiple languages

- Open bedrock.config.js
- Add the following "languages" configuration (change accordingly to which language you want to support)

```javascript
languages: [{
    id: "langEn",
    label: "English",
    default: true
  },{
    id: "langFr",
    label: "Français"
  }]
```

Them in your pug templates, you can specify multiple <span> string for each languages, see form-example.pug: 

```pug
if error
        p(style="color: red") 
            span(data-lang="langEn") Hey! Some fields were marked as invalid.
            span(data-lang="langFr") Oups! Certain champs sont invalides.

    p
        label
            span(data-lang="langEn") First Name
            span(data-lang="langFr") Nom
        input(type="text")
    p
        label
            span(data-lang="langEn") Last Name
            span(data-lang="langFr") Prénom
        input(type="text")
    p
        label
            span(data-lang="langEn") Message
            span(data-lang="langFr") Message
        textarea
```

That's it, you need to re-start bedrock in order to have the config file reloaded, and you should see a language selector in the sidebar (trigger the sidebar with CTRL + M), your language selection will be persisted.









