### PR TITLE
Make icon font CSS selector and svg icon CSS selector configurable

### DIFF
--- a/bedrock.config.js
+++ b/bedrock.config.js
@@ -23,7 +23,8 @@ module.exports = {
   icons: {
     generateIconFont: false,
     hasSvgIcons: true,
-    baseClass: 'svg-icon'
+    svgIconClassPrefix: 'svg-icon',
+    iconFontClassPrefix: 'if'
   },
   pug: {
     pretty: true,

--- a/bedrock.config.js
+++ b/bedrock.config.js
@@ -22,7 +22,8 @@ module.exports = {
   },
   icons: {
     generateIconFont: false,
-    hasSvgIcons: true
+    hasSvgIcons: true,
+    baseClass: 'svg-icon'
   },
   pug: {
     pretty: true,

--- a/content/docs/overviews/icons.pug
+++ b/content/docs/overviews/icons.pug
@@ -11,6 +11,7 @@ h2.br-documentation-header Icons
 .br-content
 
     if config.icons.hasSvgIcons
+        - var svgIconClassPrefix = config.icons && config.icons.svgIconClassPrefix || 'svg-icon'
         h3 SVG icons
 
         p
@@ -18,8 +19,8 @@ h2.br-documentation-header Icons
             | having to inline them. You can either inline them, or build a solution that does it for you.
 
         p
-            | The SVG content should be contained in a <code>.svg-icon</code> div that also get an icon-specific class based on its
-            | name (for example: <code>.svg-icon.svg-icon-add</code>. This allows us to style and colorize specific icons.
+            | The SVG content should be contained in a <code>.#{svgIconClassPrefix}</code> div that also get an icon-specific class based on its
+            | name (for example: <code>.#{svgIconClassPrefix}.#{svgIconClassPrefix}-add</code>. This allows us to style and colorize specific icons.
 
         #icon-docs
             +iconsOverview('svg', 'SVG icons')

--- a/core/scss/components/_br-sample.scss
+++ b/core/scss/components/_br-sample.scss
@@ -151,7 +151,7 @@
   column-count: 4;
   > div {
     display: flex;
-    .svg-icon, .o-svg-icon {
+    .#{$br-svg-icon-class-prefix}, .o-svg-icon {
       flex-basis: 20%;
     }
     code {

--- a/core/tasks/icon-font.js
+++ b/core/tasks/icon-font.js
@@ -11,7 +11,9 @@ const browserSync = require('browser-sync');
 const FONT_NAME = 'icon-font';
 const TMP_DIRECTORY = './icon-font-tmp';
 
-const cmd = `fontcustom compile ${paths.content.iconFont.sourceDirectory} --name ${FONT_NAME} --selector=".if-{{glyph}}" -h -o ${TMP_DIRECTORY}`;
+const iconFontClassPrefix = config.icons && config.icons.iconFontClassPrefix || 'if';
+
+const cmd = `fontcustom compile ${paths.content.iconFont.sourceDirectory} --name ${FONT_NAME} --selector=".${iconFontClassPrefix}-{{glyph}}" -h -o ${TMP_DIRECTORY}`;
 
 module.exports = function (done) {
 

--- a/core/tasks/sass.js
+++ b/core/tasks/sass.js
@@ -4,9 +4,13 @@ const gutil = require('gulp-util');
 const notifier = require('node-notifier');
 const sourcemaps = require('gulp-sourcemaps');
 const postcss = require('gulp-postcss');
+const header = require('gulp-header');
 const autoprefixer = require('autoprefixer');
 const paths = require('../paths');
 const errors = require('../util/errors');
+const config = require('../../bedrock.config');
+
+var svgIconClassPrefix = config.icons && config.icons.svgIconClassPrefix || 'svg-icon'
 
 module.exports = function () {
   const processors = [
@@ -17,6 +21,8 @@ module.exports = function () {
       paths.content.scss.allMainFiles,
       paths.core.scss.prototype
     ])
+    // Inject config svgIconPrefix in scss
+    .pipe(header('$br-svg-icon-class-prefix: ' + svgIconClassPrefix + ';\n'))
     .pipe(sourcemaps.init())
     .pipe(sass())
     .on('start', function () {

--- a/core/templates/mixins/icon-overview.pug
+++ b/core/templates/mixins/icon-overview.pug
@@ -11,6 +11,9 @@ mixin iconCategory(category, name, mode)
                     div
                         +icon([category, icon.name].join('/'))
                         code= icon.name
+
+    - var iconFontClassPrefix = config.icons && config.icons.iconFontClassPrefix || 'if';
+
     if mode === 'icon-font'
         .br-sample(id="icon-font")
             .br-sample-header.br-sample-clearfix
@@ -19,7 +22,7 @@ mixin iconCategory(category, name, mode)
             .br-sample-content
                 each icon in icons.iconFont
                     div
-                        i.if(class=`if-${icon}`)
+                        i(class=`${iconFontClassPrefix} ${iconFontClassPrefix}-${icon}`)
                         code= icon
 
 mixin iconsOverview(mode, name)

--- a/core/templates/mixins/icon.pug
+++ b/core/templates/mixins/icon.pug
@@ -1,7 +1,7 @@
-- const baseClass = config.icons && config.icons.baseClass || 'svg-icon'
-
 mixin icon(name, extraClasses)
+    - var svgIconClassPrefix = config.icons && config.icons.svgIconClassPrefix || 'svg-icon'
+    
     if extraClasses
-        div(class=`${baseClass} ${baseClass}-${name.replace('/', '-')} ${extraClasses}`)!= renderSvgIcon(name)
+        div(class=`${svgIconClassPrefix} ${svgIconClassPrefix}-${name.replace('/', '-')} ${extraClasses}`)!= renderSvgIcon(name)
     else
-        div(class=`${baseClass} ${baseClass}-${name.replace('/', '-')}`)!= renderSvgIcon(name)
+        div(class=`${svgIconClassPrefix} ${svgIconClassPrefix}-${name.replace('/', '-')}`)!= renderSvgIcon(name)

--- a/core/templates/mixins/icon.pug
+++ b/core/templates/mixins/icon.pug
@@ -1,5 +1,7 @@
+- const baseClass = config.icons && config.icons.baseClass || 'svg-icon'
+
 mixin icon(name, extraClasses)
     if extraClasses
-        .svg-icon(class=`svg-icon-${name.replace('/', '-')} ${extraClasses}`)!= renderSvgIcon(name)
+        div(class=`${baseClass} ${baseClass}-${name.replace('/', '-')} ${extraClasses}`)!= renderSvgIcon(name)
     else
-        .svg-icon(class=`svg-icon-${name.replace('/', '-')}`)!= renderSvgIcon(name)
+        div(class=`${baseClass} ${baseClass}-${name.replace('/', '-')}`)!= renderSvgIcon(name)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bedrock",
-  "version": "1.4.1",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1734,6 +1734,23 @@
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "concat-with-sourcemaps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+      "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -4274,6 +4291,38 @@
         "gulp-util": "3.0.8",
         "multimatch": "2.1.0",
         "streamfilter": "1.0.5"
+      }
+    },
+    "gulp-header": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-2.0.5.tgz",
+      "integrity": "sha512-7bOIiHvM1GUHIG3LRH+UIanOxyjSys0FbzzgUBlV2cZIIZihEW+KKKKm0ejUBNGvRdhISEFFr6HlptXoa28gtQ==",
+      "dev": true,
+      "requires": {
+        "concat-with-sourcemaps": "1.1.0",
+        "lodash.template": "4.4.0",
+        "through2": "2.0.3"
+      },
+      "dependencies": {
+        "lodash.template": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+          "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.templatesettings": "4.1.0"
+          }
+        },
+        "lodash.templatesettings": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+          "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "3.0.0"
+          }
+        }
       }
     },
     "gulp-if": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "gulp-changed": "^1.3.0",
     "gulp-data": "^1.2.0",
     "gulp-filter": "^3.0.1",
+    "gulp-header": "^2.0.5",
     "gulp-if": "^2.0.0",
     "gulp-jsbeautifier": "^1.0.1",
     "gulp-postcss": "^6.0.1",


### PR DESCRIPTION
Fix: https://github.com/mono-company/bedrock/issues/190

### Quick note

@Wolfr I think I did modify everything that is needed to have the styleguide and the feature working accordingly, it works great for the svgIcon but for the icon font I didn't managed to make it display the icon font, it's not related to my change because it's already not working on the current master, if you set generateIconFont to true in the config and open the styleguide, the "example" icon font doesn't appear:

![screen shot 2018-05-16 at 19 33 18](https://user-images.githubusercontent.com/533590/40147659-f2801e68-5940-11e8-8072-d9ff8c887bd6.png)

I didn't look further as you may already know about this issue, let me know if I should debug it. 

BTW I spent another ~2h implementing this, the most tricky part was figuring out how to inject the svg-font prefix inside the sass file in order to have the styleguide working 😉

### DOC to copy to website once integrated:

By default the svg icon and icon font class names are prefixed with `svg-icon svg-icon-${iconName}` and `if if-${iconName}`

You can modify those prefix with the following variables in the `bedrock.config.js`:

```javascript
icons: {
    svgIconClassPrefix: 'svg-icon',
    iconFontClassPrefix: 'if'
  }
```

Then don't forget to restart bedrock to reload the config file.